### PR TITLE
fix: add build step to workflow

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -30,6 +30,9 @@ jobs:
         npm install -g @capacitor/cli
         npm install -g netlify-cli
         
+    - name: Build web assets
+      run: npm run deploy
+
     - name: Sync web assets with Capacitor
       run: npx cap sync android
         


### PR DESCRIPTION
- Added `npm run deploy` to the GitHub Actions workflow to ensure the `www` directory is created before syncing with Capacitor.